### PR TITLE
fix: chip note/video indicator dot no longer clipped in workout session

### DIFF
--- a/apps/web/src/components/Workout/EffortPicker.jsx
+++ b/apps/web/src/components/Workout/EffortPicker.jsx
@@ -54,15 +54,20 @@ export default function EffortPicker({
           fontWeight: 600,
           minWidth: 34,
           minHeight: 20,
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
           display: 'inline-flex',
           alignItems: 'center',
           justifyContent: 'center',
         }}
       >
-        {primary === 'rir' && compactValue}
+        {/* El overflow:hidden del ellipsis solo envuelve el VALOR DE TEXTO (único caso que puede
+            desbordar): vivir en el span exterior recortaría la bolita, que sobresale de sus
+            límites; envolver también los iconos los blockifica como texto y descuadra su alto
+            (13px fijos) frente al de un pill con solo texto. */}
+        {primary === 'rir' && (
+          <span style={{ maxWidth: '100%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {compactValue}
+          </span>
+        )}
         {primary === 'note' && <StickyNote size={13} color={colors.textSecondary} />}
         {primary === 'video' && <Video size={13} color={colors.textSecondary} />}
         {primary === 'empty' && (showEffortScale ? '–' : <StickyNote size={13} color={colors.textMuted} />)}


### PR DESCRIPTION
## Resumen
- La bolita («hay algo más») del chip de la columna «Notas» en la fila de serie de la sesión de entrenamiento quedaba recortada: estaba posicionada `absolute` fuera de los límites del `span` que la contenía, y ese `span` tenía `overflow: hidden` (necesario para el `text-overflow: ellipsis` del valor RIR).
- Fix: el `overflow: hidden`/`text-overflow: ellipsis` ahora envuelve solo el valor de texto (RIR), dejando los iconos (nota/vídeo) y el `span` exterior (que posiciona la bolita) sin recorte. Revisado en `/gate` para que el pill no cambie de alto entre estados con icono y estados con texto.
- Verificado que el equivalente nativo (`apps/gym-native`) no tiene el mismo bug (el `View`/`Pressable` de RN no recorta por defecto), así que no requiere cambios de paridad.

## Test plan
- [x] `npm run lint` (web + native) en verde
- [x] `npm run test` — 1707 tests OK (1 suite falla por falta de vars de entorno de Supabase en este worktree, no relacionado con el cambio)
- [ ] Verificar visualmente en el navegador que la bolita se ve completa en la celda de notas