### PR TITLE
docs: require Conventional Commits PR titles and auto-merge on creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,10 @@ Cada cambio debe dejar **en el repositorio** (no solo en memorias externas) lo n
 - No co-author or AI attribution lines
 
 ## PRs y auto-merge
+**Al crear una PR en este repo (`gh pr create`):**
+1. **Título en inglés, Conventional Commits** (`feat: ...`, `fix(scope): ...`, `chore: ...`) — el check `Formato Conventional Commits` lo rechaza si no. La descripción/body sí va en español.
+2. **Activar auto-merge inmediatamente después de crearla**, sin esperar a que lo pida el usuario: `gh pr merge --auto --squash`. Es el flujo estándar del repo (ver abajo) — fusiona sola en cuanto pase el check `test`.
+
 `main` solo permite **squash merge** (sin merge commit ni rebase): cada PR aterriza como un único commit cuyo mensaje es el título de la PR (`squash_merge_commit_title: PR_TITLE`). Ese commit es lo que `scripts/bump-version.js` escanea para decidir el bump semántico, así que **el título de la PR debe seguir Conventional Commits en inglés** (`feat:`, `fix:`, `chore:`, etc. — igual que un mensaje de commit normal, ver arriba), aunque la descripción vaya en español. Lo valida el workflow `pr-title.yml` (check requerido).
 - Para activar auto-merge en una PR: `gh pr merge --auto --squash`. Se fusiona sola en cuanto el check `test` (CI) pase — no hace falta esperar ni pedir revisión.
 - `main` NO exige "pull request obligatoria" en branch protection (solo status checks) para que `version.yml` pueda pushear el commit de bump directamente a `main` tras cada merge. Tampoco exige "rama al día", para que ese commit de bump no deje cada PR abierta pendiente de "Update branch".


### PR DESCRIPTION
## Summary
- La sección "PRs y auto-merge" de `CLAUDE.md` documentaba el mecanismo (por qué el título de la PR importa, cómo activar auto-merge) pero no decía explícitamente qué hacer al crear una PR.
- Se añaden dos pasos explícitos: título en inglés con Conventional Commits, y activar `gh pr merge --auto --squash` justo después de crear la PR, sin esperar a que se pida.

## Contexto
En la PR #31/#35 el agente creó la PR con título en español (falló el check `Formato Conventional Commits`) y no activó auto-merge hasta que se le pidió aparte. Este cambio cierra ese hueco para que no se repita.